### PR TITLE
increase bytestring dependency to 0.10.2.0

### DIFF
--- a/friday-devil.cabal
+++ b/friday-devil.cabal
@@ -37,7 +37,7 @@ library
     default-language:   Haskell2010
 
     build-depends:      base                    >= 4            && < 5
-                      , bytestring              >= 0.10         && < 1
+                      , bytestring              >= 0.10.2.0     && < 1
                       , convertible             >= 1            && < 2
                       , deepseq                 >= 1.3          && < 2
                       , friday                  >= 0.2          && < 0.3


### PR DESCRIPTION
increase bytestring dependency to 0.10.2.0 to support `BS.unsafePackMallocCStringLen` function
