### PR TITLE
Update cabal config

### DIFF
--- a/friday-devil.cabal
+++ b/friday-devil.cabal
@@ -45,6 +45,4 @@ library
                       , transformers            >= 0.3          && < 0.6
                       , vector                  >= 0.10.0.1     && < 1
 
-    Build-tools:        hsc2hs
-
-    Extra-Libraries:    IL
+    pkgconfig-depends:  IL


### PR DESCRIPTION
pkgconfig-depends should be prefered if possible (cabal docs)
build-tool is deprecated and not necessary, file extesion is enough

Both changes make it buildable using IOHKs haskell.nix infrastructure.